### PR TITLE
chore(api): add backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+nba_api
+pandas
+numpy
+scikit-learn


### PR DESCRIPTION
## Summary
- add FastAPI backend dependencies list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68991a3254008323bcb21864d70d2b46