### PR TITLE
fix(web): add package.json for Railway build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "breakoutbuyer-ui",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start -p ${PORT}"
+  },
+  "dependencies": {
+    "framer-motion": "11.0.0",
+    "lucide-react": "0.453.0",
+    "next": "14.2.5",
+    "papaparse": "5.4.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.18",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.5"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}


### PR DESCRIPTION
## Summary
- add frontend package.json with Next.js build scripts and dependencies for Railway

## Testing
- `npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_689920a7f22083238efc2c935bc84f40