### PR TITLE
fix(web): add @types/papaparse

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "20.11.30",
+    "@types/papaparse": "5.2.7",
     "@types/react": "18.2.66",
     "autoprefixer": "10.4.18",
     "postcss": "8.4.35",


### PR DESCRIPTION
## Summary
- add @types/papaparse typings for frontend

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fpapaparse)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68995219839883239b21a16128b01b45