### PR TITLE
api: make GET /api/candidates non-blocking (returns 202 if not ready)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -246,8 +246,6 @@ def status():
 @app.get("/api/candidates", response_model=List[Candidate])
 def candidates():
     if not os.path.exists(CANDIDATES_PATH):
-        ranked=build_dataset()
-        if ranked.empty: return []
-        os.makedirs(os.path.dirname(CANDIDATES_PATH), exist_ok=True)
-        ranked.to_csv(CANDIDATES_PATH, index=False)
+        # Not ready yet
+        raise HTTPException(status_code=202, detail="candidates file not ready")
     return pd.read_csv(CANDIDATES_PATH).to_dict(orient="records")


### PR DESCRIPTION
## Summary
- make /api/candidates return 202 if candidates CSV is missing instead of building dataset

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689a84318afc8323b60d81fc95032bc0