### PR TITLE
Add NBA branding to header

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import Image from "next/image";
 import Papa from "papaparse";
 import { motion } from "framer-motion";
 import { Download, PlayCircle, Search, Sparkles } from "lucide-react";
@@ -111,10 +112,10 @@ export default function Page() {
     <div className="min-h-screen w-full bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-slate-900 via-black to-slate-950">
       <header className="sticky top-0 z-20 backdrop-blur bg-black/40 border-b border-cyan-500/40">
         <div className="mx-auto max-w-6xl px-4 py-4 flex items-center gap-3">
-          <div className="h-9 w-9 rounded-xl bg-gradient-to-br from-cyan-400 via-fuchsia-500 to-amber-400 animate-pulse" />
+          <Image src="/nba-logo.svg" alt="NBA logo" width={36} height={36} className="h-9 w-9 rounded-xl" />
           <div>
             <h1 className="text-xl font-bold tracking-widest uppercase">BreakoutBuyer</h1>
-            <p className="text-xs text-slate-300/80 -mt-1">Early-career breakout predictor · Retro Card UI</p>
+            <p className="text-xs text-slate-300/80 -mt-1">Early-career NBA breakout predictor</p>
           </div>
           <div className="ml-auto flex items-center gap-2">
             {lastUpdated && <span className="text-xs text-slate-400">Updated {lastUpdated}</span>}

--- a/frontend/public/nba-logo.svg
+++ b/frontend/public/nba-logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <rect width="96" height="96" fill="#17408B"/>
+  <rect x="48" width="48" height="96" fill="#C8102E"/>
+  <text x="48" y="68" font-size="48" font-family="sans-serif" font-weight="bold" text-anchor="middle" fill="#FFFFFF">NBA</text>
+</svg>


### PR DESCRIPTION
## Summary
- Replace placeholder div with NBA logo image in header
- Update subtitle to "Early-career NBA breakout predictor"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689aadadbd708323a17d64b5afa10650