### PR TITLE
Group candidate file details in health endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -235,9 +235,11 @@ def health():
     try:
         if os.path.exists(CANDIDATES_PATH):
             st = os.stat(CANDIDATES_PATH)
-            info["candidates_path"] = CANDIDATES_PATH
-            info["candidates_bytes"] = int(st.st_size)
-            info["candidates_mtime"] = dt.datetime.utcfromtimestamp(st.st_mtime).isoformat() + "Z"
+            info["candidates"] = {
+                "path": CANDIDATES_PATH,
+                "bytes": int(st.st_size),
+                "mtime": dt.datetime.utcfromtimestamp(st.st_mtime).isoformat() + "Z",
+            }
     except Exception:
         pass
     try:


### PR DESCRIPTION
## Summary
- Consolidate candidate file metadata under `candidates` in `/api/health` response.

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689ab09e64fc8323b1752b0c830a4650