### PR TITLE
Capitalize status phases in poller

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -116,7 +116,8 @@ export default function Page() {
         const eta = s?.eta_sec ? ` · ETA ${Math.max(0, s.eta_sec)}s` : "";
         const last = s?.last_name ? ` · ${s.last_name}` : "";
         setPct(perc);
-        setStatusText(`${phase}${total ? ` ${done}/${total}` : ""}${last}${eta}`);
+        const pretty = (phase || "").replace(/_/g, " ").replace(/\b\w/g, (c: string) => c.toUpperCase());
+        setStatusText(`${pretty}${total ? ` ${done}/${total}` : ""}${last}${eta}`);
       } catch {}
     }, 2000);
     return () => clearInterval(id);


### PR DESCRIPTION
## Summary
- Format and capitalize status phases when polling model run status to produce human-friendly messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d516260f88323b53432cbacc52498