### PR TITLE
Increase game log pull progress frequency

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -177,7 +177,7 @@ def build_dataset(min_season=MIN_SEASON, max_season=MAX_SEASON):
             )
             continue
 
-        if i % 10 == 0 or i == total:
+        if i % 5 == 0 or i == total:
             dt_s = max(time.time() - start_pull, 1e-6)
             rps = i / dt_s
             eta = int(max(0, (total - i) / rps)) if rps > 0 else None


### PR DESCRIPTION
## Summary
- update progress logs to report every 5 players when pulling game logs

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689ea110d7e483238ac116f3875cfa65