### PR TITLE
Add fast_pipeline flag to runModel fetch

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -78,7 +78,7 @@ export default function Page() {
     const t0 = Date.now();
     try {
       // kick off build
-      const r = await fetch(`${apiBase}/api/run?fast=1`, { method: "POST" });
+      const r = await fetch(`${apiBase}/api/run?fast_pipeline=1`, { method: "POST" });
       if (!r.ok) {
         const msg = await r.text().catch(()=> "");
         throw new Error(`POST /api/run ${r.status} ${msg}`);


### PR DESCRIPTION
## Summary
- ensure `runModel` triggers backend fast pipeline by adding `fast_pipeline=1` query parameter

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc0da96948323a3fd7ac4a3dd309f